### PR TITLE
fix: adjustment-invalid-date-on-firefox

### DIFF
--- a/helpers/olinda-promise/index.js
+++ b/helpers/olinda-promise/index.js
@@ -6,22 +6,21 @@ import config from '../../config'
 const olindaPromise = async date => {
   const quoteDate = date || dateFns.format(new Date(), 'MM-DD-YYYY')
   let quotation = await axios
-    .get(
-      `${config.olindaApi}/CotacaoDolarDia(dataCotacao=@dataCotacao)?@dataCotacao='${quoteDate}'`,
-    )
+    .get(`${config.olindaApi}/CotacaoDolarDia(dataCotacao=@dataCotacao)?@dataCotacao='${quoteDate}'`)
     .then(res => res.data)
 
   if (quotation.value.length === 0) {
     if (dateFns.getDay(quoteDate) === 0) {
-      const datePlusOne = dateFns.addDays(quoteDate, 1)
+      const datePlusOne = dateFns.addDays(new Date(), 1)
       quotation = await olindaPromise(dateFns.format(datePlusOne, 'MM-DD-YYYY'))
 
       return quotation
     }
 
     if (dateFns.getDay(quoteDate) === 6 || dateFns.getDay(quoteDate) !== 0) {
-      const dateLessOne = dateFns.subDays(quoteDate, 1)
+      const dateLessOne = dateFns.subDays(new Date(), 1)
       quotation = await olindaPromise(dateFns.format(dateFns.subDays(dateLessOne, 1), 'MM-DD-YYYY'))
+
       return quotation
     }
   }


### PR DESCRIPTION
When passing the date formatted for addDays or subDays function firefox returns invalid date or format invalid.

this problem caused return `error 500 in olinda API` 

**RFC**
date-fns/issues/742
date-fns/issues/746